### PR TITLE
Add python package classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,10 @@ dependencies = ["jupyter-client>=7.0"]
 requires-python = ">=3.8"
 readme = "README.rst"
 license = { text = "BSD-3-Clause" }
+classifiers = [
+  "Topic :: Utilities",
+  "Framework :: Jupyter",
+]
 
 [project.urls]
 "Homepage" = "https://github.com/casangi/sshpyk?tab=readme-ov-file#remote-jupyter-kernels-via-ssh"


### PR DESCRIPTION
@schiebel Small PR to label on PyPi that sshpyk integrates with Jupyter, can facilitate the package being discovered by other people. Someone from iPython [recommended](https://github.com/ipython/ipython/issues/10934#issuecomment-3392973338) this.