### PR TITLE
Make config validation less strict, add `raise_on_ssh_config_error`

### DIFF
--- a/sshpyk/cli.py
+++ b/sshpyk/cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from jupyter_client.kernelspec import KernelSpecManager
 
-from .provisioning import RGX_KERNEL_NAME, RGX_SSH_HOST_ALIAS
+from .provisioning import RGX_KERNEL_NAME
 from .utils import (
     LAUNCH_TIMEOUT,
     SHUTDOWN_TIME,
@@ -424,12 +424,6 @@ def add_kernel(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
-    # Validate SSH host alias
-    if not RGX_SSH_HOST_ALIAS.match(args.ssh_host_alias):
-        print(f"Error: Invalid SSH host alias '{args.ssh_host_alias}'")
-        print(f"Must match pattern: {RGX_SSH_HOST_ALIAS.pattern!r}")
-        sys.exit(1)
-
     # Validate remote kernel name
     if not RGX_KERNEL_NAME.match(args.remote_kernel_name):
         print(f"Error: Invalid remote kernel name '{args.remote_kernel_name}'")
@@ -550,10 +544,6 @@ def edit_kernel(args: argparse.Namespace) -> None:
     if args.ssh:
         config["ssh"] = args.ssh
     if args.ssh_host_alias:
-        if not RGX_SSH_HOST_ALIAS.match(args.ssh_host_alias):
-            print(f"Error: Invalid SSH host alias '{args.ssh_host_alias}'")
-            print(f"Must match pattern: {RGX_SSH_HOST_ALIAS.pattern}")
-            sys.exit(1)
         config["ssh_host_alias"] = args.ssh_host_alias
 
     if args.remote_python:

--- a/sshpyk/utils.py
+++ b/sshpyk/utils.py
@@ -217,7 +217,7 @@ def validate_ssh_config(config: Dict[str, Union[str, List[str]]]):
     if "identityfile" in keys:
         id_file = config.get("identityfile", None)
         if id_file:
-            fp = Path(id_file).resolve()  # type: ignore
+            fp = Path(id_file).expanduser().resolve()  # type: ignore
             if fp.exists():
                 out["identityfile"] = ("ok", str(fp))
             else:
@@ -261,7 +261,7 @@ def validate_ssh_config(config: Dict[str, Union[str, List[str]]]):
         c_path = config.get("controlpath", None)
         recommended = "~/.ssh/sshpyk_%r@%h_%p"
         if c_path:
-            dp = Path(c_path).resolve().parent  # type: ignore
+            dp = Path(c_path).expanduser().resolve().parent  # type: ignore
             if dp.exists():
                 out["controlpath"] = ("ok", c_path)
             else:


### PR DESCRIPTION
@schiebel this PR is a follow up from the issues raised by @dwa

I mainly removed the strict checks and cleanup the code and error messages.

Fixes #9 
Supersedes #10 